### PR TITLE
Add haggertk to the things and perform general clean-up

### DIFF
--- a/github/data.yml
+++ b/github/data.yml
@@ -8,6 +8,7 @@ Developer Relations:
   members:
     - ciwrl
     - fourkbomb
+    - haggertk
     - luca020400
     - luk1337
     - mikeNG
@@ -19,8 +20,8 @@ Head Developers:
   meta:
     id: 2589670
   members:
-    - ciwrl
     - fourkbomb
+    - haggertk
     - luca020400
     - luk1337
     - mikeNG
@@ -34,24 +35,26 @@ Maintainers:
   members:
     - ciwrl
     - fourkbomb
+    - haggertk
+    - harryyoud
+    - javelinanddart
+    - jrizzoli
     - luca020400
     - luk1337
     - mikeNG
+    - npjohnson
     - Rashed97
     - razorloves
     - sam3000
     - zifnab06
-    - javelinanddart
-    - harryyoud
-    - jrizzoli
-    - npjohnson
 Public Relations:
   meta:
     id: 2713795
   members:
     - ciwrl
-    - zifnab
+    - haggertk
     - harryyoud
     - javelinanddart
     - jrizzoli
     - npjohnson
+    - zifnab06


### PR DESCRIPTION
* Devrel, Head Developers, Maintainers, PR
* Pull ciwrl from Head Developers
* Sort these things because I value sanity
* Fix zif's github username so that some rando cannot do whatever
  level of PR things that this allows

Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>